### PR TITLE
ci(github): use action in pull-request-summary.yml

### DIFF
--- a/.github/workflows/pull-request-summary.yml
+++ b/.github/workflows/pull-request-summary.yml
@@ -9,27 +9,5 @@ jobs:
   pull-request-summary:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup ollama
-        uses: ai-action/setup-ollama@v1
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Pull request summary
-        run: |
-          PROMPT=$(printf '%s\n%s' "$PROMPT" "$(gh pr diff $PR_NUMBER)")
-          RESPONSE=$(ollama run codellama "$PROMPT" | sed 's/^/> /')
-          BODY=$(gh pr view $PR_NUMBER --json body --jq .body)
-          COMMENT_START='<!--pull-request-review-start-->'
-          COMMENT_END='<!--pull-request-review-end-->'
-          if [[ "$BODY" == *"$COMMENT_START"* ]]; then
-            # delete between patterns (inclusive)
-            BODY=$(echo "$BODY" | sed '/<!--pull-request-review-start-->/,/<!--pull-request-review-end-->/d')
-          fi
-          BODY=$(printf '%s\n%s\n> [!NOTE]\n%s\n%s\n' "$BODY" $COMMENT_START "$RESPONSE" $COMMENT_END)
-          gh pr edit $PR_NUMBER --body "$BODY"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PROMPT: |
-            Summarize code diff succinctly:
+        uses: ai-action/pull-request-summary@v1


### PR DESCRIPTION
## What is the motivation for this pull request?

ci(github): use action in pull-request-summary.yml

## What is the current behavior?

Not using action

## What is the new behavior?

Uses [pull-request-summary](https://github.com/ai-action/pull-request-summary)

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->

<!--pull-request-summary-start-->

> [!NOTE]
>  The code in this pull request adds a new step to the "pull-request-summary" job that runs the "pull-request-summary" action, which is responsible for summarizing the code diff in a concise manner. The `ollama` tool is used to generate a summary of the code changes, and the resulting summary is then added as a comment to the pull request.
> 
> The step also includes some error handling to ensure that any existing comments with the same pattern are removed before adding the new comment. This is done by checking if the body of the pull request contains a specific comment start/end pattern, and deleting all text between that pattern if it does.
> 

<!--pull-request-summary-end-->